### PR TITLE
Add "Get Started" Button

### DIFF
--- a/routes/botman.php
+++ b/routes/botman.php
@@ -1,11 +1,18 @@
 <?php
 
-use Facades\App\Feed;
-use App\Http\Controllers\BotManController;
-use App\Notifications\Subscribed;
 use App\User;
+use Facades\App\Feed;
+use BotMan\Drivers\Facebook\Extensions\ElementButton;
+use BotMan\Drivers\Facebook\Extensions\ButtonTemplate;
 
 $botman = resolve('botman');
+
+$botman->hears('get_started', function ($bot) {
+    $buttons = ButtonTemplate::create('Hi! You can subscribe to our podcast, so you will be notified when we have new episodes available.')
+        ->addButton(ElementButton::create('Subscribe')->type('postback')->payload('subscribe'));
+
+    $bot->reply($buttons);
+});
 
 $botman->hears('.*(Hi|Hello|Hey).*', function ($bot) {
     $bot->reply('Hello! What can I do for you today? Try "info" for more information.');

--- a/tests/BotMan/FacebookSubscriptionTest.php
+++ b/tests/BotMan/FacebookSubscriptionTest.php
@@ -3,13 +3,25 @@
 namespace Tests\BotMan;
 
 use App\User;
-use Illuminate\Foundation\Inspiring;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\BotMan\BotManTestCase;
+use BotMan\Drivers\Facebook\Extensions\ElementButton;
+use BotMan\Drivers\Facebook\Extensions\ButtonTemplate;
 
 class FacebookSubscriptionTest extends BotManTestCase
 {
     use RefreshDatabase;
+
+    /** @test */
+    function get_started_greets_users()
+    {
+        $buttons = ButtonTemplate::create('Hi! You can subscribe to our podcast, so you will be notified when we have new episodes available.')
+            ->addButton(ElementButton::create('Subscribe')->type('postback')->payload('subscribe'));
+
+        $this->bot->receives('get_started')
+            ->assertTemplate(ButtonTemplate::class);
+
+        $this->assertEquals($this->bot->getMessages()[0], $buttons);
+    }
 
     /** @test */
     function subscribe_subscribes_user()


### PR DESCRIPTION
This PR adds the ability to listen for a "Get Started" button on Facebook Messenger, similar to this one:

![image](https://user-images.githubusercontent.com/804684/35947636-219a2fb0-0c69-11e8-9a85-150a556d6c04.png)

So when people visit your Facebook Messenger app for the first time, instead of seeing a blank "input" field, they will see a "Get Started" button which they can press.

The code in this PR listens to the payload that this button can send to the bot, and will then return a text message and a button that people can use to subscribe to your podcast by clicking on it.

---

In order to make use of this change, you need to tell your Facebook Messenger application to use the "Get Started" button with the payload `get_started`.

Since this repository has the BotMan Studio commands installed, you can simply do this by calling `php artisan botman:facebookAddStartButton` once, as the default payload is set to `get_started` in the `config/botman/facebook.php` file.